### PR TITLE
Add profiling

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,22 @@
+# go-mdism
+
+## Profiling
+
+Profiles can be generated in the google [perftools](https://code.google.com/p/gperftools/) format (.pprof).
+Profiles are generated using the go benchmarking facility:
+
+```
+go test -bench cpu
+go test -bench mem
+```
+
+See `benchmark_test.go` to view the different profiles. By default profile results are output to `tmp`.
+
+To visualize the profiles, you will need to install perftools (`brew install google-perftools` on osx).
+
+```
+go tool pprof --pdf (which go-mdism) tmp/cpu.pprof  > test.pdf
+```
+
+## Todo
+* Make profiling simpler. Maybe have a makefile that allows for a simple `make profile-cpu` that automatically generates and opens the results in your browser.

--- a/benchmark_test.go
+++ b/benchmark_test.go
@@ -1,0 +1,49 @@
+package main
+
+import (
+	"fmt"
+	"github.com/davecheney/profile"
+	"os"
+	"strconv"
+	"testing"
+)
+
+var results_path = "tmp"
+var person_count = 1000
+
+func init() {
+	var err error
+
+	count := os.Getenv("PERSON_COUNT")
+	if count != "" {
+		person_count, err = strconv.Atoi(count)
+	}
+
+	if err != nil {
+		fmt.Println(err)
+	}
+	fmt.Println("person_count=", person_count)
+	fmt.Println("Profiling ...")
+}
+
+func BenchmarkMemoryProfile(b *testing.B) {
+	createPeople(person_count)
+	cfg := profile.Config{
+		ProfilePath: results_path, // store profiles in current directory
+		CPUProfile:  true,
+	}
+
+	defer profile.Start(&cfg).Stop()
+	runModel()
+}
+
+func BenchmarkCPUProfile(b *testing.B) {
+	createPeople(person_count)
+	cfg := profile.Config{
+		ProfilePath: results_path, // store profiles in current directory
+		MemProfile:  true,
+	}
+
+	defer profile.Start(&cfg).Stop()
+	runModel()
+}

--- a/benchmark_test.go
+++ b/benchmark_test.go
@@ -22,7 +22,7 @@ func init() {
 	if err != nil {
 		fmt.Println(err)
 	}
-	fmt.Println("person_count=", person_count)
+	fmt.Println("person_count is", person_count)
 	fmt.Println("Profiling ...")
 }
 

--- a/index.go
+++ b/index.go
@@ -147,6 +147,10 @@ func main() {
 
 	// table tests here
 
+	runModel()
+}
+
+func runModel() {
 	for _, cycle := range Cycles { // foreach cycle
 		fmt.Println("Cycle: ", cycle.Name)
 		for _, person := range People { // 	foreach person
@@ -168,7 +172,6 @@ func main() {
 		//fmt.Println("Debugging stop")
 		//os.Exit(1)
 	} // end foreach cycle
-
 }
 
 func runPersonCycleModel(person Person, cycle Cycle, model Model) {

--- a/index.go
+++ b/index.go
@@ -12,7 +12,6 @@ import (
 	// 	"net/http"
 	// 	"strconv"
 	"encoding/csv"
-	"github.com/davecheney/profile"
 	"math"
 	"math/rand"
 	"os"
@@ -128,22 +127,12 @@ var Cycles = []Cycle{
 var MasterRecords = []MasterRecord{}
 
 func main() {
-
-	cfg := profile.Config{
-		MemProfile:     false,
-		ProfilePath:    ".",  // store profiles in current directory
-		NoShutdownHook: true, // do not hook SIGINT
-		CPUProfile:     true,
-	}
-
-	defer profile.Start(&cfg).Stop()
+	// Seed the random function
+	rand.Seed(time.Now().UTC().UnixNano())
 
 	// create people will generate individuals and add their data to the master
 	// records
 	createPeople(1000)
-
-	// Seed the random function
-	rand.Seed(time.Now().UTC().UnixNano())
 
 	// table tests here
 


### PR DESCRIPTION
This keeps the profile tests in one file.
Profiles can be generated individually by using the standard go benchmark facility, example:

```
go test -bench cpu
```

or

```
go test -bench mem
```

`go test -bench` would run all of them, but given the way the model is currently written, this fails.

tests results go to `tmp`, though that could be made configurable if ever needed
